### PR TITLE
Lift to SpeziLLM v0.7 dependency

### DIFF
--- a/ExampleApplication.xcodeproj/project.pbxproj
+++ b/ExampleApplication.xcodeproj/project.pbxproj
@@ -1205,7 +1205,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/Spezi";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.0;
+				minimumVersion = 1.2.1;
 			};
 		};
 		2FB099B42A875E2B00B20952 /* XCRemoteSwiftPackageReference "HealthKitOnFHIR" */ = {
@@ -1253,7 +1253,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziQuestionnaire.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.0.2;
 			};
 		};
 		2FE5DC8829EDD972004B9AB4 /* XCRemoteSwiftPackageReference "SpeziStorage" */ = {
@@ -1317,7 +1317,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziLLM";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.6.1;
+				minimumVersion = 0.7.0;
 			};
 		};
 		97F466E62A76BBEE005DC9B4 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */ = {
@@ -1325,7 +1325,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziOnboarding";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ExampleApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ExampleApplication.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "b880ec8ec927a838c51c12862c6222c30d7097d7",
-        "version" : "10.20.0"
+        "revision" : "f91c8167141d0279726c6f6d9d4a47c026785cbc",
+        "version" : "10.21.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "ceec9f28dea12b7cf3dabf18b5ed7621c88fd4aa",
-        "version" : "10.20.0"
+        "revision" : "cb8617fab75d181270a1d8f763f26b15c73e2e1e",
+        "version" : "10.21.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "115f75e43851774934d695449a4836123c3246e1",
-        "version" : "3.2.0"
+        "revision" : "76135c9f4e1ac85459d5fec61b6f76ac47ab3a4c",
+        "version" : "3.3.1"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MacPaw/OpenAI",
       "state" : {
-        "revision" : "ac5892fd0de8d283362ddc30f8e9f1a0eaba8cc0",
-        "version" : "0.2.5"
+        "revision" : "35afc9a6ee127b8f22a85a31aec2036a987478af",
+        "version" : "0.2.6"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
-        "version" : "2.3.1"
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/ResearchKit",
       "state" : {
-        "revision" : "209164ed20592a2213c4bd69cefcb078d9de0692",
-        "version" : "2.2.21"
+        "revision" : "15f06cf7c1d2d22805b7b939823536bc78ad63a6",
+        "version" : "2.2.25"
       }
     },
     {
@@ -158,8 +158,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/ResearchKitOnFHIR",
       "state" : {
-        "revision" : "ea4d9691591594177e7dfbc8c246324855d73eb5",
-        "version" : "1.0.1"
+        "revision" : "300fbc0038df28f53a9b653298931f71aa6f0bb5",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "semaphore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/Semaphore.git",
+      "state" : {
+        "revision" : "f1c4a0acabeb591068dea6cffdd39660b86dec28",
+        "version" : "0.0.8"
       }
     },
     {
@@ -167,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi",
       "state" : {
-        "revision" : "c4bf0e99de40acfdd2baf0fa02769f06a4c3f0eb",
-        "version" : "1.1.0"
+        "revision" : "0ced3efbc2af9513c07ac913ad762c773a00a6c8",
+        "version" : "1.2.1"
       }
     },
     {
@@ -176,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount.git",
       "state" : {
-        "revision" : "714f01ae1e67bf9c1c0e7c07624380f9bea772b7",
-        "version" : "1.1.0"
+        "revision" : "a7d289ef3be54de62b25dc92e8f7ff1a0f093906",
+        "version" : "1.2.1"
       }
     },
     {
@@ -185,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziChat",
       "state" : {
-        "revision" : "9d45c10bcf859c98f2998ecd4f6a80f31894fe2c",
-        "version" : "0.1.4"
+        "revision" : "eae5c15b211f18e09aa98de63ce119629320afeb",
+        "version" : "0.1.8"
       }
     },
     {
@@ -212,8 +221,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFoundation.git",
       "state" : {
-        "revision" : "d1e6d4cddcf236038d21a73d671806d8ba51b01c",
-        "version" : "1.0.1"
+        "revision" : "0346857e2f1d6fd4b1d950d271be6c82df97107f",
+        "version" : "1.0.2"
       }
     },
     {
@@ -221,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
       "state" : {
-        "revision" : "d882734a4ed31fce1bffd7b9977e2669080f21de",
-        "version" : "0.5.0"
+        "revision" : "b40695ffa4d1c9d58c5a0ee277640c2343fb5516",
+        "version" : "0.5.1"
       }
     },
     {
@@ -230,8 +239,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziLLM",
       "state" : {
-        "revision" : "94c1f3bd3eb9412e3321a46730c1572da11bd951",
-        "version" : "0.6.1"
+        "revision" : "6892c5dfe258371b6f3287f02b8fec57a611ba70",
+        "version" : "0.7.0"
       }
     },
     {
@@ -248,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziOnboarding",
       "state" : {
-        "revision" : "8fb6d9f1a080661c0cc564a93b82ead3c8d44d4f",
-        "version" : "1.0.2"
+        "revision" : "91463ae190611bd14ef52b0657e8db3bf53c9ae8",
+        "version" : "1.1.0"
       }
     },
     {
@@ -257,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziQuestionnaire.git",
       "state" : {
-        "revision" : "fac0bb02f7027b4c09bd7afdad55eb7b47ec67f3",
-        "version" : "1.0.1"
+        "revision" : "f25580e95bfdad02383980dcb94406cf97b08ea8",
+        "version" : "1.0.2"
       }
     },
     {
@@ -266,8 +275,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziScheduler.git",
       "state" : {
-        "revision" : "adf793cb47dc199f8ae88f5c719f4d3ba06a4c4e",
-        "version" : "0.8.0"
+        "revision" : "ba391084109a9a16622b07e9dcefe2ab1552d2a2",
+        "version" : "0.8.1"
       }
     },
     {
@@ -275,8 +284,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziSpeech",
       "state" : {
-        "revision" : "a1e1d021d8f605b5e6b23aee773115d7125a57e3",
-        "version" : "1.0.0"
+        "revision" : "60b8cdbf6f3d58b0d75eadf30db50f88848069aa",
+        "version" : "1.0.1"
       }
     },
     {
@@ -293,8 +302,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziViews.git",
       "state" : {
-        "revision" : "0137e69d156bf4001a8d6bf5661c9a37b2bbd0aa",
-        "version" : "1.0.0"
+        "revision" : "d49f716e4a4d634604bb0dcd6d53df679b6c1358",
+        "version" : "1.3.0"
       }
     },
     {
@@ -311,8 +320,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
-        "version" : "1.0.6"
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
       }
     },
     {
@@ -338,8 +347,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTestExtensions.git",
       "state" : {
-        "revision" : "fb7fcee97c574b950e03b0a53874e26db27db2fe",
-        "version" : "0.4.8"
+        "revision" : "1fe9b8e76aeb7a132af37bfa0892160c9b662dcc",
+        "version" : "0.4.10"
       }
     },
     {
@@ -356,8 +365,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTRuntimeAssertions",
       "state" : {
-        "revision" : "bb2a287c2544aa846e53670d1ece35e5949567be",
-        "version" : "1.0.0"
+        "revision" : "51da3403f128b120705571ce61e0fe190f8889e6",
+        "version" : "1.0.1"
       }
     }
   ],

--- a/ExampleApplication/ExampleApplicationDelegate.swift
+++ b/ExampleApplication/ExampleApplicationDelegate.swift
@@ -60,8 +60,8 @@ class ExampleApplicationDelegate: SpeziAppDelegate {
             OnboardingDataSource()
             
             LLMRunner {
-                LLMLocalRunnerSetupTask()
-                LLMOpenAIRunnerSetupTask()
+                LLMLocalPlatform()
+                LLMOpenAIPlatform()
             }
         }
     }

--- a/ExampleApplication/LLMInteraction/LLMInteraction.swift
+++ b/ExampleApplication/LLMInteraction/LLMInteraction.swift
@@ -14,30 +14,32 @@ import SwiftUI
 
 /// Showcases a minimal demo of SpeziLLM
 struct LLMInteraction: View {
-    @Binding var presentingAccount: Bool
-    
-    @State var showOnboarding = true
-    
-    /// OpenAI model
-    @State var openAIModel: LLM = LLMOpenAI(
+    private static let llmOpenAISchema = LLMOpenAISchema(
         parameters: .init(
-            modelType: .gpt4_1106_preview,
+            modelType: .gpt4_turbo_preview,
             systemPrompt: "You're speaking in front of Stanford students, be as funny and ironic as possible."
         )
     ) {
         LLMOpenAIFunctionWeather()
     }
-    
-    /// Local Llama2 model
-    @State var localModel: LLM = LLMLocal(
+    private static let localSchema = LLMLocalSchema(
         modelPath: .cachesDirectory.appending(path: "llm.gguf"),
         contextParameters: .init(contextWindowSize: 1024)
     )
     
+    @Binding var presentingAccount: Bool
+    @State var showOnboarding = true
+    
+    /// OpenAI model
+    @LLMSessionProvider(schema: llmOpenAISchema) var openAIModel: LLMOpenAISession
+    /// Local Llama2 model
+    @LLMSessionProvider(schema: localSchema) var localModel: LLMLocalSession
+    
+    
     var body: some View {
         NavigationStack {
             LLMChatView(
-                model: openAIModel
+                session: $openAIModel
             )
                 .navigationTitle("LLM_CHAT_VIEW_TITLE")
                 .toolbar {
@@ -61,8 +63,8 @@ struct LLMInteraction: View {
     LLMInteraction(presentingAccount: .constant(true))
         .previewWith {
             LLMRunner {
-                LLMLocalRunnerSetupTask()
-                LLMOpenAIRunnerSetupTask()
+                LLMLocalPlatform()
+                LLMOpenAIPlatform()
             }
         }
 }

--- a/ExampleApplication/LLMInteraction/LLMInteraction.swift
+++ b/ExampleApplication/LLMInteraction/LLMInteraction.swift
@@ -22,7 +22,7 @@ struct LLMInteraction: View {
     ) {
         LLMOpenAIFunctionWeather()
     }
-    private static let localSchema = LLMLocalSchema(
+    private static let llmLocalSchema = LLMLocalSchema(
         modelPath: .cachesDirectory.appending(path: "llm.gguf"),
         contextParameters: .init(contextWindowSize: 1024)
     )
@@ -33,7 +33,7 @@ struct LLMInteraction: View {
     /// OpenAI model
     @LLMSessionProvider(schema: llmOpenAISchema) var openAIModel: LLMOpenAISession
     /// Local Llama2 model
-    @LLMSessionProvider(schema: localSchema) var localModel: LLMLocalSession
+    @LLMSessionProvider(schema: llmLocalSchema) var localModel: LLMLocalSession
     
     
     var body: some View {

--- a/ExampleApplication/LLMInteraction/Local/LLMLocalDownloadOnboarding.swift
+++ b/ExampleApplication/LLMInteraction/Local/LLMLocalDownloadOnboarding.swift
@@ -19,6 +19,7 @@ struct LLMLocalDownloadOnboarding: View {
     
     var body: some View {
         LLMLocalDownloadView(
+            downloadDescription: "The application will download the LLama2 7B model which is around 3.5GB",
             llmDownloadUrl: LLMLocalDownloadManager.LLMUrlDefaults.llama2ChatModelUrl,
             llmStorageUrl: .cachesDirectory.appending(path: "llm.gguf")
         ) {

--- a/ExampleApplication/Resources/Localizable.xcstrings
+++ b/ExampleApplication/Resources/Localizable.xcstrings
@@ -469,6 +469,9 @@
         }
       }
     },
+    "The application will download the LLama2 7B model which is around 3.5GB" : {
+
+    },
     "WELCOME_AREA1_DESCRIPTION" : {
       "localizations" : {
         "en" : {


### PR DESCRIPTION
# Lift to SpeziLLM v0.7 dependency

## :recycle: Current situation & Problem
The Intake app currently depends on SpeziLLM v0.6, which is outdated as of last week.
SpeziLLM v0.7 contains breaking API changes, therefore leading to compile errors within the project.


## :gear: Release Notes 
- Lift the SpeziLLM dependency to v0.7 and adjust to breaking API changes.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).